### PR TITLE
Fix link to Probability and Statistics Cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ A curated list of awesome mathematics resources.
 * [Introduction to Probability](http://vfu.bg/en/e-Learning/Math--Bertsekas_Tsitsiklis_Introduction_to_probability.pdf) - Dimitri P. Bertsekas, John N. Tsitsiklis (MIT)
 * [A Short Introduction to Probability](http://www.maths.uq.edu.au/~kroese/asitp.pdf) - Dirk P. Kroese (University of Queensland)
 * [Probability: Theory and Examples](https://www.math.duke.edu/~rtd/PTE/PTE4_1.pdf) - Rick Durrett
-* [Probability and Statistics Cookbook](http://matthias.vallentin.net/probability-and-statistics-cookbook/cookbook-en.pdf) - Matthias Vallentin (UC Berkeley)
+* [Probability and Statistics Cookbook](https://github.com/mavam/stat-cookbook/releases/download/0.2.3/stat-cookbook.pdf) - Matthias Vallentin (UC Berkeley)
 * [The Only Probability Cheatsheet You'll Ever Need](http://www.wzchen.com/probability-cheatsheet/) - William Chen
 
 ### Statistics


### PR DESCRIPTION
It's now located under https://github.com/mavam/stat-cookbook

Too bad it's not possible to link to the latest release on Github.