### PR TITLE
The project Dzdx has changed the name to MathRelay. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A curated list of awesome mathematics resources.
 * [Mathigon](https://mathigon.org/)
 * [Calculus.org](http://calculus.org/)
 * [Ximera](https://ximera.osu.edu/) : free interactive mathematics textbooks (Ohio State University)
-* [Dzdx.xyz](https://www.dzdx.xyz/)
+* [MathRelay](https://www.mathrelay.com/)
 * [Almost Fun](https://www.almostfun.org/lessons/)
 * [Oxford Mathematics](https://www.youtube.com/c/OxfordMathematics)
 


### PR DESCRIPTION
dzdx.xyz redirects to mathrelay.com