### PR TITLE
Add LearnGraphTheory.org – Free Graph Theory Learning Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ All resources are freely available except those with a 💲 icon.
 
 * 📝 [Graph Theory: Lecture Notes](http://www.personal.psu.edu/cxg286/Math485.pdf) - Christopher Griffin
 * 📝 [Graph Theory](http://www.cs.unibo.it/babaoglu/courses/cas00-01/tutorials/GraphTheory.pdf) - Reinhard Diestel
+* 📝 [Graph Theory : Interactive Algorithm Visualizer | Graph Theory Learning Platform](https://learngraphtheory.org/) - Hadjoudj Mohammed Islam 
 
 
 ## Geometry and Topology


### PR DESCRIPTION
Added [LearnGraphTheory.org](https://learngraphtheory.org) to the Graph Theory section.

It’s a free, interactive platform that offers structured lessons and visualizations for learning graph theory. Suitable for students, developers, and self-learners interested in algorithms, discrete math, or networks.
