### PR TITLE
Add MathCalculator to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ All resources are freely available except those with a 💲 icon.
 * [Corca Editor](https://corca.io/)
 * [RunMat](https://github.com/runmat-org/runmat) - Runtime for MATLAB-syntax array math with automatic CPU/GPU execution.
 * [Structural Engineering Tools (SEPCO Engineering)](https://github.com/sepcostructural/structural-engineering-tools) - Free online calculators for beam diagrams, Canadian steel section properties, and pressure conversions.
+* [MathCalculator](https://mathcalculator.org) - Free online math calculator with 104+ calculators covering algebra, calculus, statistics, geometry and more, with step-by-step solutions.
 
 
 ## Questions and Answers


### PR DESCRIPTION
Adds [MathCalculator.org](https://mathcalculator.org) to the Tools section. MathCalculator is a free online math platform with 104+ calculators (algebra, calculus, statistics, geometry, etc.), step-by-step solutions with no paywall, multi-language support (EN/DE/ES), and embeddable widgets.