### PR TITLE
Add Androma to Encyclopedia section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ All resources are freely available except those with a 💲 icon.
 
 ## Encyclopedia
 
+* [Androma](https://androma.org) - Open mathematics wiki with theorem database, proofs, prerequisite tracking, spaced repetition study tools, and collaborative LaTeX editing.
 * [Encyclopedia of Mathematics](https://www.encyclopediaofmath.org)
 * [Planetmath](http://planetmath.org/)
 * [ProofWiki](https://proofwiki.org/wiki/Main_Page)


### PR DESCRIPTION
Adds [Androma](https://androma.org) to the Encyclopedia section.

Androma is an open mathematics wiki featuring:
- Theorem database with formal statements and proofs
- Prerequisite tracking between topics
- Spaced repetition study tools
- Collaborative LaTeX editing (similar to Overleaf)
- All content is CC BY-SA 4.0

It sits alongside ProofWiki and PlanetMath as an open math reference.