### PR TITLE
Add methods-harness to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ All resources are freely available except those with a 💲 icon.
 * [Corca Editor](https://corca.io/)
 * [RunMat](https://github.com/runmat-org/runmat) - Runtime for MATLAB-syntax array math with automatic CPU/GPU execution.
 * [Structural Engineering Tools (SEPCO Engineering)](https://github.com/sepcostructural/structural-engineering-tools) - Free online calculators for beam diagrams, Canadian steel section properties, and pressure conversions.
+* [methods-harness](https://github.com/lfzds4399-cpu/methods-harness) - SymPy-verified pipeline producing bilingual (EN/中文) VCE Mathematical Methods 3-4 lessons, cheat sheets, and mock SAC papers from one CLI. Validators gate every formula before PDF render. MIT.
 
 
 ## Questions and Answers


### PR DESCRIPTION
Adds [methods-harness](https://github.com/lfzds4399-cpu/methods-harness) to the Tools section.

A SymPy-verified pipeline that produces bilingual (English / 中文) study material for VCE Mathematical Methods 3-4: lesson PDFs, cheat sheets, mock SAC papers, and matplotlib diagrams from a single CLI. Every formula is checked symbolically by validators before PDF render — typos in derivatives or integrals fail the build, not the student.

Built on SymPy / Jinja2 / matplotlib. MIT-licensed, 21 unit tests, runs offline. Suitable for any educator producing their own structured math materials, not only VCE.