### PR TITLE
Add Chesser Resources and Learro to Learning Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ All resources are freely available except those with a 💲 icon.
 * [Oxford Mathematics](https://www.youtube.com/c/OxfordMathematics)
 * [Math Academy](https://mathacademy.com/)
 * [Derivative Calculus Solver](https://www.derivativecalculus.com) — A step-by-step differentiation tool focusing on the chain rule and substitution logic.
+* [Learro](https://learro.com/) — Free study guides, practice exams, and formula sheets for AP Calculus AB/BC and AP Statistics, plus other AP courses.
+* [Chesser Resources](https://chesserresources.com.au/new/) — Free document-sharing platform with math notes, exam papers (JEE Mains, CBSE), and academic resources. Free signup required to download.
 
 ## Learn to Learn
 


### PR DESCRIPTION
Adds two free educational resources:

- **[Chesser Resources](https://chesserresources.com.au/new/)** — Free document-sharing platform: study notes, exam papers (JEE Mains, CBSE), and subject notes. Free signup required for downloads (anti-bot, no paywall — site has no pricing page).
- **[Learro](https://learro.com/)** — Free AP exam prep: study guides, practice exams, formula sheets, and scoring guidelines. No signup or paywall.