### PR TITLE
Add NovaSolver (interactive physics simulators) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ All resources are freely available except those with a 💲 icon.
 * [Corca Editor](https://corca.io/)
 * [RunMat](https://github.com/runmat-org/runmat) - Runtime for MATLAB-syntax array math with automatic CPU/GPU execution.
 * [Structural Engineering Tools (SEPCO Engineering)](https://github.com/sepcostructural/structural-engineering-tools) - Free online calculators for beam diagrams, Canadian steel section properties, and pressure conversions.
+* [NovaSolver](https://novasolver.jp/tools/) - 1,600+ interactive physics and engineering simulators (beam deflection, Lissajous figures, Lorenz attractor, Mohr's circle, heat diffusion, etc.) running entirely in the browser. [Source on GitHub](https://github.com/novasolver/physics-simulators).
 
 
 ## Questions and Answers


### PR DESCRIPTION
Hi! Proposing to add NovaSolver to the Tools section.

NovaSolver is a collection of 1,600+ interactive physics and engineering simulators that run entirely client-side in the browser. Many use core mathematical concepts (ODEs, PDEs, linear algebra, complex analysis, chaos theory, Fourier analysis) and would be useful for self-learners visualizing what they read.

A few representative examples for context:
- Lissajous figures: https://novasolver.jp/tools/lissajous.html
- Lorenz attractor: https://novasolver.jp/tools/lorenz-attractor.html
- Mohr's circle: https://novasolver.jp/tools/mohr-circle.html
- Heat diffusion 2D: https://novasolver.jp/tools/heat-diffusion.html
- Bifurcation diagram: https://novasolver.jp/tools/bifurcation-diagram.html

Source code (MIT): https://github.com/novasolver/physics-simulators

The site is free, no signup, no install. Multilingual (JA/EN/ZH).

Thanks for maintaining this list!
