### PR TITLE
Add Statistics Calculator to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ All resources are freely available except those with a 💲 icon.
 * [Corca Editor](https://corca.io/)
 * [RunMat](https://github.com/runmat-org/runmat) - Runtime for MATLAB-syntax array math with automatic CPU/GPU execution.
 * [Structural Engineering Tools (SEPCO Engineering)](https://github.com/sepcostructural/structural-engineering-tools) - Free online calculators for beam diagrams, Canadian steel section properties, and pressure conversions.
+* [Statistics Calculator (Nutilz)](https://nutilz.com/statistics-calculator) - Free online tool that computes mean, median, mode, standard deviation, variance, and quartiles from any list of numbers.
 
 
 ## Questions and Answers


### PR DESCRIPTION
Adds a free online Statistics Calculator (mean, median, mode, standard deviation, variance, quartiles) to the Tools section, alongside the existing Midpoint Calculator and Quartiles Calculator entries.

- Link: https://nutilz.com/statistics-calculator
- No signup required, computes results client-side from any list of numbers.