### PR TITLE
Add nLab to Encyclopedia section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ All resources are freely available except those with a 💲 icon.
 * [Planetmath](http://planetmath.org/)
 * [ProofWiki](https://proofwiki.org/wiki/Main_Page)
 * [Wolfram Mathworld](http://mathworld.wolfram.com/)
+* [nLab](https://ncatlab.org) - A collaborative wiki for mathematics, physics, and philosophy, with an emphasis on higher category theory and homotopy theory.
 * [The On-Line Encyclopedia of Integer Sequences](https://oeis.org) - Great compendium of many different integer sequences. Founded 1964 by N. J. A. Sloane.
 * 💲 [The Princeton Companion to Mathematics](https://press.princeton.edu/books/hardcover/9780691118802/the-princeton-companion-to-mathematics) - Timothy Gowers (Professor, Fields medallist), June Barrow-Green (Professor), and Imre Leader (Professor).
 * 💲 [Encyclopedia of Distances (4th Edition)](https://link.springer.com/book/10.1007/978-3-662-52844-0) - Michel Marie Deza, Elena Deza.


### PR DESCRIPTION
Closes #160

Adds [nLab](https://ncatlab.org) to the Encyclopedia section, alongside the other math wikis/encyclopedias already listed (Encyclopedia of Mathematics, Planetmath, ProofWiki, Wolfram Mathworld). nLab is a well-established collaborative wiki for mathematics, physics, and philosophy, particularly strong in category theory and homotopy theory.