### PR TITLE
Add L-System Generator to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ All resources are freely available except those with a 💲 icon.
 * [Corca Editor](https://corca.io/)
 * [RunMat](https://github.com/runmat-org/runmat) - Runtime for MATLAB-syntax array math with automatic CPU/GPU execution.
 * [Structural Engineering Tools (SEPCO Engineering)](https://github.com/sepcostructural/structural-engineering-tools) - Free online calculators for beam diagrams, Canadian steel section properties, and pressure conversions.
+* [L-System Generator](https://alltoolsverse.com/tools/l-system-generator/) - Expand Lindenmayer systems from an axiom and substitution rules over a chosen number of iterations.
 
 
 ## Questions and Answers


### PR DESCRIPTION
## What changed

- Added L-System Generator to General Resources > Tools.

## Why it fits

L-systems are a mathematical formalism used to expand strings from an axiom and substitution rules. The browser tool gives readers a focused way to experiment with those systems without signing up.

## Validation

- Searched the README and pull request history for All Tools Verse, L-system, Lindenmayer, and fractal collisions.
- Live-tested `A=AB`, `B=A`, axiom `A`, and 5 iterations.
- Confirmed the output was `ABAABABAABAAB`.
- Confirmed the change is one addition in one file.

Disclosure: I build All Tools Verse and am submitting this resource myself. This contribution was prepared with assistance from OpenAI Codex.