### PR TITLE
Add lightweight repository validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,42 @@
+name: Validate
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate the repository
+        run: python scripts/validate.py
+
+      - name: Validate issue templates
+        run: ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.{yml,yaml}"].each { |file| YAML.load_file(file) }'
+
+      - name: Run Awesome lint
+        run: npx --yes awesome-lint@2.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,15 @@ Do not remove a resource based only on a timeout, `403` response, or other
 automated link-check result. Look for a current official page and confirm the
 resource status first.
 
+## Local checks
+
+Before submitting a pull request, run:
+
+```shell
+python scripts/validate.py
+npx --yes awesome-lint@2.3.0
+```
+
 ## Review
 
 Inclusion is an editorial decision. A declined nomination may still be useful or

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,90 @@
+"""Run stable, offline checks for the Awesome Math repository."""
+
+from collections import Counter
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parent.parent
+README = ROOT / "README.md"
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(ROOT))
+
+import build_toc  # noqa: E402
+
+
+ENTRY_PATTERN = re.compile(
+    r"^\s*\* \[[^\]]+\]\(https://[^)]+\) - .+\.$"
+)
+HEADING_PATTERN = re.compile(r"^#{2,} .+$", re.MULTILINE)
+URL_PATTERN = re.compile(r"https?://[^)\s]+")
+START_TOC = "<!-- START_TOC -->"
+END_TOC = "<!-- END_TOC -->"
+
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+
+def check_toc(readme):
+    require(readme.count(START_TOC) == 1,
+            "README must contain one start-of-TOC marker")
+    require(readme.count(END_TOC) == 1,
+            "README must contain one end-of-TOC marker")
+    with tempfile.TemporaryDirectory() as directory:
+        copy = Path(directory) / "README.md"
+        copy.write_text(readme, encoding="utf-8")
+        build_toc.gen_toc(copy)
+        require(copy.read_text(encoding="utf-8") == readme,
+                "README table of contents is out of date")
+
+
+def check_entries(readme):
+    body = readme.split(END_TOC, maxsplit=1)[1]
+    entries = [line for line in body.splitlines()
+               if re.match(r"^\s*\* \[", line)]
+    invalid = [line for line in entries if not ENTRY_PATTERN.fullmatch(line)]
+    require(not invalid,
+            "Invalid resource entry format:\n" + "\n".join(invalid))
+    return len(entries)
+
+
+def check_urls(readme):
+    urls = URL_PATTERN.findall(readme)
+    require(all(url.startswith("https://") for url in urls),
+            "README contains a plain HTTP URL")
+    duplicates = sorted(url for url, count in Counter(urls).items()
+                        if count > 1)
+    require(not duplicates,
+            "Duplicate README URLs:\n" + "\n".join(duplicates))
+    return len(urls)
+
+
+def check_headings(readme):
+    headings = HEADING_PATTERN.findall(readme)
+    duplicates = sorted(heading for heading, count
+                        in Counter(headings).items() if count > 1)
+    require(not duplicates,
+            "Duplicate README headings:\n" + "\n".join(duplicates))
+    anchors = [build_toc._anchor(heading.split(" ", maxsplit=1)[1])
+               for heading in headings]
+    duplicate_anchors = sorted(anchor for anchor, count
+                               in Counter(anchors).items() if count > 1)
+    require(not duplicate_anchors,
+            "Duplicate README anchors:\n" + "\n".join(duplicate_anchors))
+
+
+def main():
+    readme = README.read_text(encoding="utf-8")
+    require(readme.endswith("\n"), "README must end with a newline")
+    check_toc(readme)
+    entry_count = check_entries(readme)
+    url_count = check_urls(readme)
+    check_headings(readme)
+    print(f"Validated {entry_count} resource entries and {url_count} URLs.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add a small validation workflow for pull requests and changes to `master`.

The workflow checks:

- README entry format;
- table of contents consistency;
- duplicate URLs, headings, and generated anchors;
- HTTPS usage;
- issue-template YAML;
- Awesome list conventions.

It also documents the main local validation commands in `CONTRIBUTING.md`.

## Design

The workflow has read-only repository access. Official GitHub actions are pinned to commit SHAs. Obsolete runs are cancelled when a pull request receives another commit.

Live link checking is excluded because many academic sites block automated requests. Link failures still require manual review.

## Checks

- `python scripts/validate.py`
- issue-template and workflow YAML parsing
- `npx --yes awesome-lint@2.3.0`
- Actionlint 1.7.12
- `git diff --check`
