### PR TITLE
Add durable AI and mathematics resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/resource.yml
+++ b/.github/ISSUE_TEMPLATE/resource.yml
@@ -29,6 +29,25 @@ body:
       required: true
 
   - type: dropdown
+    id: resource_type
+    attributes:
+      label: Resource type
+      options:
+        - Book or lecture notes
+        - Course or tutorial
+        - Reference or encyclopedia
+        - Software or interactive tool
+        - Dataset or benchmark
+        - Seminar or recurring series
+        - Workshop or conference archive
+        - Article, essay, or case study
+        - Community or publication
+        - Curated list
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
     id: area
     attributes:
       label: Area

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,26 @@ A paid resource may qualify when it is widely respected, unusually useful, and
 hard to replace. The entry must state any paywall, registration requirement,
 limited free plan, or other access restriction.
 
+## Talks, essays, and event archives
+
+Talks, essays, seminars, and workshops may qualify when they offer lasting
+mathematical value. Prefer a stable series page or archive over an individual
+announcement.
+
+A recurring series should have a useful archive or clear evidence of continued
+stewardship. A completed workshop should provide recordings, notes,
+proceedings, code, data, or another substantial record. Pages whose main use is
+registration or a current schedule are usually too temporary.
+
+An individual post or case study needs a high bar. Claims about mathematical
+discovery or proof should link to a paper, formal proof, reproducible code,
+released data, or careful independent assessment. The description should make
+the verification method and the role of human review clear.
+
+We usually decline company announcements without supporting technical material,
+live leaderboards, current model rankings, and posts whose value depends on
+recent news.
+
 ## Self-authored resources and AI assistance
 
 You may nominate your own work. State your relationship to it. Self-authored

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Read the [contribution guidelines](CONTRIBUTING.md) before suggesting a resource
 * [Rocq Prover](https://rocq-prover.org/) - Open-source interactive theorem prover and dependently typed programming language for mechanized mathematics and verified software.
 * [Mathematical Components](https://math-comp.github.io/) - Rocq libraries and tools for large-scale formalized mathematics, including substantial developments in algebra and analysis.
 * [Metamath](https://us.metamath.org/) - Minimal formal language and proof verifier with explicit, inspectable proofs built from simple foundations.
+* [Lean-related Conferences and Events](https://leanprover-community.github.io/events.html) - Maintained calendar and archive of conferences, workshops, and tutorials about Lean, mathlib, and formalized mathematics.
 
 ## Algebra
 
@@ -587,9 +588,13 @@ Read the [contribution guidelines](CONTRIBUTING.md) before suggesting a resource
 
 This section covers AI-assisted theorem proving, formalization, and mathematical discovery. Resources that teach the mathematics used in machine learning appear under Mathematics for Machine Learning.
 
-* [LeanDojo v2](https://github.com/lean-dojo/LeanDojo-v2) - Open-source framework for training, evaluating, and deploying AI-assisted theorem provers for Lean 4.
+* [LeanDojo v2](https://leandojo.org/leandojo.html) - Open-source framework and benchmark data for training, evaluating, and deploying AI-assisted theorem provers for Lean 4.
 * [miniF2F](https://github.com/facebookresearch/miniF2F) - Cross-system benchmark of formalized olympiad, high-school, and undergraduate problems for evaluating automated theorem provers.
 * [AlphaGeometry](https://github.com/google-deepmind/alphageometry) - Open research implementation combining learned guidance with symbolic deduction for olympiad geometry problems.
+* [First Proof Project](https://1stproof.org/) - Independent project that publishes research-level problems, evaluation methods, solutions, and expert commentary for assessing AI systems in mathematics.
+* [Math AI Seminar](https://math.washington.edu/events/series/math-ai-seminar) - University of Washington research seminar on formalization, theorem proving, mathematical AI, and machine-learning applications in mathematics, with a multi-year event archive.
+* [b=M²L](https://bm2l.github.io/) - Barcelona Mathematics and Machine Learning colloquia on the interaction between mathematics and machine learning, with multi-year editions and recorded talks.
+* [AI for Mathematics and Theoretical Computer Science](https://simons.berkeley.edu/workshops/simons-institute-theory-computing-slmath-joint-workshop-ai-mathematics-theoretical) - Simons Institute and SLMath workshop archive with recorded talks on proof assistants, automated reasoning, machine learning, and mathematical discovery.
 
 ### Mathematical Software and Tools
 


### PR DESCRIPTION
## Summary

- add five durable AI and mathematics resources
- add rules for talks, essays, seminars, workshops, and case studies
- add a resource-type field to the nomination form
- point LeanDojo v2 to its official project page

## Why

Recent activity in AI and mathematics belongs in the list when it has lasting
mathematical value. These additions favor maintained calendars, recurring
series, recorded workshop archives, and independent assessment.

The new contribution rules set a higher bar for short-lived announcements,
leaderboards, model rankings, and claims without supporting technical material.

## Checks

- `python scripts/validate.py`
- `npx --yes awesome-lint@2.3.0`
- nomination form YAML parse
- direct checks of all new and updated links
- `git diff --check`
